### PR TITLE
fix: colors not being cleared in .vim

### DIFF
--- a/colors/candyland.vim
+++ b/colors/candyland.vim
@@ -1,3 +1,5 @@
+highlight clear
+
 highlight! link NvimSpacing Normal
 highlight! link NvimTreePopup Normal
 highlight Bold guifg=NONE guibg=NONE guisp=NONE blend=NONE gui=bold


### PR DESCRIPTION
If you load a different color scheme then run ```colorscheme candyland```, some of the colors are not being overwritten. Adding a simple ```highlight clear``` fixes this issue. I am not sure this affects everyone, but it did for me and this fixed it.